### PR TITLE
feat: image-visibility changes on a scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build on Tag
+name: Create Release
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [ 2024/03/11 - v1.1.1 ]
+
+### Changed/Added
+
+* Setting images to private by default and will only set to public once a scan has passed successfully - this can still
+  be overridden at the config level.
+
 ## [ 2024/02/29 - v1.1.0 ]
 
 ### BREAKING CHANGES

--- a/baski-example.yaml
+++ b/baski-example.yaml
@@ -147,6 +147,8 @@ scan:
     # How many concurrent scans to perform.
     concurrency: 2
   # Override the cloud.[provider].flavor for the scan. This can help avoid using a large or gpu enabled node just for scanning.
+  # This is only really needed if you're using a single config for all steps of Baski.
+  # If Baski is run in a pipeline, the scan step may generate its own config on demand and therefore the cloud.[provider].flavor would be sufficient.
   flavor-name: "not-so-spicy-meatball"
   # Whether to auto-delete the image. This has been added for automation purposes in the scenario where the image is built then scanned right away.
   # Should the scan fail then the image shouldn't be available publicly and so can be automatically deleted from the infrastructure to make sure a vulnerable image is not deployed.

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -46,6 +46,9 @@ It does the following:
 * Generates a report file that you can read with your eyes or via other means
 
 If the checks for CVE flags/config values are set then it will bail out and generate a report with the CVEs that caused it to do so.
+
+If a scan succeeds and cloud.[provider].image-visibility hasn't been set, then it will be made public. Otherwise it'll be left as private.
+If a visibility has been set in the config, this will be respected and no changes to the image visibility will be made.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.SetOptionsFromViper()

--- a/pkg/providers/openstack/image.go
+++ b/pkg/providers/openstack/image.go
@@ -125,7 +125,7 @@ func (c *ImageClient) FetchImage(imgID string) (*images.Image, error) {
 }
 
 // TagImage Tags the image with the passed or failed property.
-func (s *ImageClient) TagImage(properties map[string]interface{}, imgID, value, tagName string) error {
+func (c *ImageClient) TagImage(properties map[string]interface{}, imgID, value, tagName string) error {
 	// Default to replace unless the field isn't found below
 	operation := images.ReplaceOp
 
@@ -133,9 +133,25 @@ func (s *ImageClient) TagImage(properties map[string]interface{}, imgID, value, 
 	if err != nil || field == nil {
 		operation = images.AddOp
 	}
-	_, err = s.ModifyImageMetadata(imgID, tagName, value, operation)
+	_, err = c.ModifyImageMetadata(imgID, tagName, value, operation)
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// ChangeImageVisibility modifies the visibility of the image in OpenStack
+func (c *ImageClient) ChangeImageVisibility(imgID string, visibility images.ImageVisibility) error {
+	opts := images.UpdateOpts{
+		images.UpdateVisibility{Visibility: visibility},
+	}
+
+	// Throw away the image result as we don't need it moving forward here. Either it updated, or it didn't
+	_, err := images.Update(c.client, imgID, opts).Extract()
+
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/util/flags/openstack.go
+++ b/pkg/util/flags/openstack.go
@@ -107,12 +107,12 @@ func (q *OpenStackFlags) AddFlags(cmd *cobra.Command, viperPrefix string) {
 	BoolVarWithViper(cmd, &q.UseFloatingIP, viperPrefix, "use-floating-ip", true, "Whether to use a floating IP for the instance")
 	StringVarWithViper(cmd, &q.FloatingIPNetworkName, viperPrefix, "floating-ip-network-name", "public1", "The Name of the network in which to create the floating ip")
 	StringVarWithViper(cmd, &q.SecurityGroup, viperPrefix, "security-group", "", "Specify the security groups to attach")
-	StringVarWithViper(cmd, &q.ImageVisibility, viperPrefix, "image-visibility", "private", "Change the image visibility in Openstack - you need to ensure the use you're authenticating with has permissions to do so or this will fail")
+	StringVarWithViper(cmd, &q.ImageVisibility, viperPrefix, "image-visibility", "", "Change the image visibility in Openstack - you need to ensure the use you're authenticating with has permissions to do so or this will fail")
 	StringVarWithViper(cmd, &q.ImageDiskFormat, viperPrefix, "image-disk-format", "", "The image disk format in Openstack")
 	StringVarWithViper(cmd, &q.UseBlockStorageVolume, viperPrefix, "use-blockstorage-volume", "", "Use Block Storage service volume for the instance root volume instead of Compute service local volume")
 	StringVarWithViper(cmd, &q.VolumeType, viperPrefix, "volume-type", "", "Type of the Block Storage service volume. If this isn't specified, the default enforced by your OpenStack cluster will be used")
 	IntVarWithViper(cmd, &q.VolumeSize, viperPrefix, "volume-size", 0, "Size of the Block Storage service volume in GB. If this isn't specified, it is set to source image min disk value (if set) or calculated from the source image bytes size. Note that in some cases this needs to be specified, if use_blockstorage_volume is true")
-	
+
 	q.OpenStackCoreFlags.AddFlags(cmd, viperPrefix)
 	q.OpenStackInstanceFlags.AddFlags(cmd, viperPrefix)
 

--- a/pkg/util/interfaces/openstack.go
+++ b/pkg/util/interfaces/openstack.go
@@ -31,6 +31,7 @@ type OpenStackImageClient interface {
 	RemoveImage(imgID string) error
 	FetchImage(imgID string) (*images.Image, error)
 	TagImage(properties map[string]interface{}, imgID, value, tagName string) error
+	ChangeImageVisibility(imgID string, visibility images.ImageVisibility) error
 }
 
 type OpenStackNetworkClient interface {


### PR DESCRIPTION
If a scan succeeds and cloud.[provider].image-visibility hasn't been set, then it will be made public. Otherwise it'll be left as private. If a visibility has been set in the config, this will be respected and no changes to the image visibility will be made.

# What's Changed

# Why is it required?

# PR checklist
- [x] Run tests locally
- [ ] Updated Readme
- [x] Updated Changelog
