### PR TITLE
fix: correcting when the k8s metadata should be applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [ 2024/09/10 - v1.2.3]
+
+### Add/Updated
+* Updated go modules
+* fixed bug where k8s version wasn't being tagged onto metadata for openstack
+
 ## [ 2024/09/05 - v1.2.2]
 
 ### Add/Updated

--- a/baski-example.yaml
+++ b/baski-example.yaml
@@ -87,13 +87,13 @@ build:
   # The crictl version.
   crictl-version: "1.26.0"
   # The CNI version.
-  cni-version: "1.2.0"
+  cni-version: "1.5.1"
   # The specific version of the CNI Debian package ('kubernetes-cni') to install.
-  cni-deb-version: "1.2.0-2.1"
+  cni-deb-version: "1.5.1-1.1"
   # The Kubernetes version.
-  kubernetes-version: "1.28.2"
+  kubernetes-version: "1.31.0"
   # The specific version of the Kubernetes Debian packages ('kubeadm', 'kubelet') to install.
-  kubernetes-deb-version: "1.28.2-1.1"
+  kubernetes-deb-version: "1.31.0-1.1"
   # Any additional debs to install. Currently, Baski only supports ubuntu and flatcar and this will only work with Ubuntu.
   extra-debs: "nfs-common"
   # Whether to add Trivy into the image.

--- a/pkg/provisoner/provisoners.go
+++ b/pkg/provisoner/provisoners.go
@@ -87,18 +87,18 @@ func generateBuilderMetadata(o *flags.BuildOptions) map[string]string {
 		gpuVersion = fmt.Sprintf("v%s", o.AMDVersion)
 	}
 
+	metaPrefix := o.OpenStackCoreFlags.MetadataPrefix
 	meta := map[string]string{
 		"date": time.Now().Format(time.RFC3339),
 		"os":   o.BuildOS,
+		fmt.Sprintf("%s:kubernetes_version", metaPrefix): fmt.Sprintf("v%s", o.KubeVersion),
 	}
 
-	metaPrefix := o.OpenStackCoreFlags.MetadataPrefix
 	if o.AddGpuSupport {
 		gpuMeta := map[string]string{
 			fmt.Sprintf("%s:gpu_vendor", metaPrefix):         gpuVendor,
 			fmt.Sprintf("%s:gpu_models", metaPrefix):         strings.ToUpper(o.GpuModelSupport),
 			fmt.Sprintf("%s:gpu_driver_version", metaPrefix): gpuVersion,
-			fmt.Sprintf("%s:kubernetes_version", metaPrefix): fmt.Sprintf("v%s", o.KubeVersion),
 			fmt.Sprintf("%s:virtualization", metaPrefix):     o.GpuInstanceSupport,
 		}
 		for k, v := range gpuMeta {


### PR DESCRIPTION
# What's Changed
Fixing when k8s version metadata is applied as previously it was only done if a GPU driver was built 

# Why is it required?
To correct how metadata is applied

# PR checklist
- [x] Run tests locally
- [ ] Updated Readme
- [x] Updated Changelog
