### PR TITLE
Initial flag deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.6] - 2025-01-10
+
+### Removed
+- Removed flags - flags are still coded in for now but they are no longer added to the commands themselves so can no longer be used - flag code to be removed in next release
+
 ## [1.2.5] - 2025-01-10
 
 ### Changed
+- Changelog update by @drew-viles
 - Updating go modules by @drew-viles in [#24](https://github.com/drewbernetes/baski/pull/24)
 
 ## [1.2.4] - 2024-12-12
@@ -81,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## New Contributors
 * @drew-viles made their first contribution
+[1.2.6]: https://github.com/drewbernetes/baski/compare/v1.2.5..v1.2.6
 [1.2.5]: https://github.com/drewbernetes/baski/compare/v1.2.4..v1.2.5
 [1.2.4]: https://github.com/drewbernetes/baski/compare/v1.2.3..v1.2.4
 [1.2.3]: https://github.com/drewbernetes/baski/compare/v1.2.2..v1.2.3

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -27,10 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	imageBuilderRepo = "https://github.com/kubernetes-sigs/image-builder"
-)
-
 // NewBuildCommand creates a command that allows the building of an image.
 func NewBuildCommand() *cobra.Command {
 	o := &flags.BuildOptions{}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -104,8 +104,6 @@ By using this, the time is reduced and automation can be enabled.`,
 		},
 	}
 
-	o.AddFlags(cmd, imageBuilderRepo)
-
 	return cmd
 }
 

--- a/pkg/cmd/scan/scan.go
+++ b/pkg/cmd/scan/scan.go
@@ -72,7 +72,5 @@ If a visibility has been set in the config, this will be respected and no change
 		},
 	}
 
-	o.AddFlags(cmd)
-
 	return cmd
 }

--- a/pkg/cmd/sign/generate.go
+++ b/pkg/cmd/sign/generate.go
@@ -80,7 +80,5 @@ It will generate a public and private key that can then be stored securely.
 		},
 	}
 
-	o.AddFlags(cmd)
-
 	return cmd
 }

--- a/pkg/cmd/sign/image.go
+++ b/pkg/cmd/sign/image.go
@@ -81,7 +81,6 @@ If using vault, the key should be stored as follows:
 			return nil
 		},
 	}
-	o.AddFlags(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/sign/validate.go
+++ b/pkg/cmd/sign/validate.go
@@ -67,7 +67,6 @@ This just validates a signature. It's useful for verifying a signed image.
 			return nil
 		},
 	}
-	o.AddFlags(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
# What's Changed
Flags are still coded in for now but they are no longer added to the commands themselves so can no longer be used - flag code to be removed in next release

# Why is it required?
Because the flags are becoming complex and rarely used. The config file is supported better and will be the path forward.

# PR checklist
- [x] Run tests locally
- [ ] Updated Readme
- [x] Updated Changelog
