### PR TITLE
changing how concurrent image scanning works to improve error checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.8] - 2025-01-10
+
+### Changed
+- Changing how concurrent image scanning works to imrpove error checking
+
 ## [1.2.7] - 2025-01-10
 
+### Changed
+- Updating changelog by @drew-viles
+
 ### Fixed
-- Fixing trivy panics when ignoreList is len 0
+- Fixing trivy panics when ignoreList is len 0 by @drew-viles
 
 ## [1.2.6] - 2025-01-10
 
@@ -92,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## New Contributors
 * @drew-viles made their first contribution
+[1.2.8]: https://github.com/drewbernetes/baski/compare/v1.2.7..v1.2.8
 [1.2.7]: https://github.com/drewbernetes/baski/compare/v1.2.6..v1.2.7
 [1.2.6]: https://github.com/drewbernetes/baski/compare/v1.2.5..v1.2.6
 [1.2.5]: https://github.com/drewbernetes/baski/compare/v1.2.4..v1.2.5

--- a/pkg/provisoner/openstack.go
+++ b/pkg/provisoner/openstack.go
@@ -254,7 +254,7 @@ func (s *OpenStackScanProvisioner) ScanImages() error {
 				err = s.scanServer(sc, &wg)
 
 				if err != nil {
-					errChan <- fmt.Errorf("failed to scan image %s: %w", img, err)
+					errChan <- fmt.Errorf("failed to scan image %v: %w", img, err)
 				}
 			}
 		}()

--- a/pkg/provisoner/openstack.go
+++ b/pkg/provisoner/openstack.go
@@ -236,29 +236,48 @@ func (s *OpenStackScanProvisioner) ScanImages() error {
 	}
 
 	// Let's scan a bunch of images based on the concurrency
-	semaphore := make(chan struct{}, o.Concurrency)
+
+	// Error collection channel
+	errChan := make(chan error, len(imgs))
+	imageChan := make(chan images.Image)
+
+	// Worker Pool
 	var wg sync.WaitGroup
+	wg.Add(o.Concurrency)
 
-	for _, img := range imgs {
-		wg.Add(1)
-		semaphore <- struct{}{}
-		go func(image images.Image) {
-			defer func() {
-				<-semaphore // Release the slot in the semaphore
-			}()
+	for i := 0; i < o.Concurrency; i++ {
+		go func() {
+			defer wg.Done()
 
-			sc := scanner.NewOpenStackScanner(s.computeClient, s.imageClient, s.networkClient, s3Conn, severity, &image)
-			err = s.scanServer(sc, &wg)
-			// TODO: This needs to generate an error where possible as any pipelines should register a failure, not a successful completion.
-			if err != nil {
-				log.Println(err)
+			for img := range imageChan {
+				sc := scanner.NewOpenStackScanner(s.computeClient, s.imageClient, s.networkClient, s3Conn, severity, &img)
+				err = s.scanServer(sc, &wg)
+
+				if err != nil {
+					errChan <- fmt.Errorf("failed to scan image %s: %w", img, err)
+				}
 			}
-
-		}(img)
+		}()
 	}
-	wg.Wait()
 
-	close(semaphore)
+	go func() {
+		for _, img := range imgs {
+			wg.Add(1)
+			imageChan <- img
+		}
+		close(imageChan)
+	}()
+	wg.Wait()
+	close(errChan)
+
+	//Collect Errors
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("encounted errors during image scanning: %v", errs)
+	}
 
 	return nil
 }


### PR DESCRIPTION
# What's Changed
Channel errors were occurring in baski-action after a recent update. Whilst not related to Baski itself, I took the opportunity to slightly improve the process as well as fix #16 by having some error checking happen which would cause an actual error to be returned rather than logged. 

# Why is it required?
Because Stone Cold said so.

# PR checklist
- [x] Run tests locally
- [ ] Updated Readme
- [x] Updated Changelog
